### PR TITLE
Update cov_factory.cc

### DIFF
--- a/src/cov_factory.cc
+++ b/src/cov_factory.cc
@@ -72,16 +72,19 @@ namespace libgp {
     } 
     covf = registry.find(func)->second();
     if (left == right) {
-      assert(covf->init(input_dim));
+      bool res = covf->init(input_dim);
+      assert(res);
     } else if (sep == 0) {
       size_t sep = arg.find_first_of('/');
       int filter = atoi(arg.substr(1,sep-1).c_str());
       std::string second = arg.substr(sep+1, arg.length() - sep - 2);
-      assert(covf->init(input_dim, filter, create(1, second)));
+      bool res = covf->init(input_dim, filter, create(1, second));
+      assert(res);
     } else {
-      assert(covf->init(input_dim, 
+      bool res = covf->init(input_dim, 
             create(input_dim, arg.substr(1,sep-1)), 
-            create(input_dim, arg.substr(sep+1, arg.length()-sep-2))));
+            create(input_dim, arg.substr(sep+1, arg.length()-sep-2)));
+      assert(res);
     }
     return covf;
   }


### PR DESCRIPTION
Covarience function is not initialize in the case of NDEBUG define. In such case assert is defined as "((void)0)" see: http://en.cppreference.com/w/cpp/error/assert

NDEBUG is widely used to make Eigen faster, so can be a critical problem