### PR TITLE
Changed googletest to pull from git instead of svn

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,7 +2,8 @@ INCLUDE(ExternalProject)
 
 # ----- Download and build gtest -----
 ExternalProject_Add(googletest
-  SVN_REPOSITORY "http://googletest.googlecode.com/svn/tags/release-1.7.0"
+  GIT_REPOSITORY "https://github.com/google/googletest.git"
+  GIT_TAG "release-1.7.0"
   INSTALL_COMMAND ""
   UPDATE_COMMAND ""
   PREFIX "gtest"


### PR DESCRIPTION
At least for me, I could not get googletest from the svn link specified in the Cmake file. I changed this to git which fixed it for me, see change below.
