### PR TITLE
Change googletest dependency to git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "gtest"]
+	path = gtest
+	url = https://github.com/google/googletest.git

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,13 +1,3 @@
-INCLUDE(ExternalProject)
-
-# ----- Download and build gtest -----
-ExternalProject_Add(googletest
-  SVN_REPOSITORY "http://googletest.googlecode.com/svn/tags/release-1.7.0"
-  INSTALL_COMMAND ""
-  UPDATE_COMMAND ""
-  PREFIX "gtest"
-)
-
 FIND_PACKAGE(Threads REQUIRED)
 
 # ----- Testing -----


### PR DESCRIPTION
Instead of having CMake download the googletest git repository as implemented in #9 we can embed googletest as submodule.
I don't know which way is "better", I just solved the problem this way and later found the other pull request.

For cloning a fresh copy you would use git clone git@......git --recursive, for cloning gtest into an existing working copy of the repo call
git submodule init
git submodule update
