### PR TITLE
Rprop improvements

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "gtest"]
+	path = gtest
+	url = https://github.com/google/googletest.git

--- a/include/rprop.h
+++ b/include/rprop.h
@@ -16,8 +16,8 @@ class RProp
 {
 public:
   RProp () {init();}
-  void init(double eps_stop = 0.0, double Delta0=0.1, double Deltamin=1e-6, double Deltamax=50, double etaminus=0.5, double etaplus=1.2);
-  void maximize(GaussianProcess * gp, size_t n=100, bool verbose=1);
+  void init(double eps_stop = 0.0, double Delta0=0.1, double Deltamin=1e-6, double Deltamax=50, double etaminus=0.5, double etaplus=1.2, double min_stepsize_factor = 1e-2);
+  void maximize(GaussianProcess * gp, size_t n=100, bool verbose=true, bool print_params = false);
 private:
   double Delta0;
   double Deltamin;
@@ -25,6 +25,7 @@ private:
   double etaminus;
   double etaplus;
   double eps_stop;
+  double min_stepsize_factor;
 };
 }
 

--- a/src/rprop.cc
+++ b/src/rprop.cc
@@ -11,7 +11,7 @@
 
 namespace libgp {
 
-void RProp::init(double eps_stop, double Delta0, double Deltamin, double Deltamax, double etaminus, double etaplus) 
+void RProp::init(double eps_stop, double Delta0, double Deltamin, double Deltamax, double etaminus, double etaplus, double min_stepsize_factor)
 {
   this->Delta0   = Delta0;
   this->Deltamin = Deltamin;
@@ -19,10 +19,10 @@ void RProp::init(double eps_stop, double Delta0, double Deltamin, double Deltama
   this->etaminus = etaminus;
   this->etaplus  = etaplus;
   this->eps_stop = eps_stop;
-
+  this->min_stepsize_factor = min_stepsize_factor;
 }
 
-void RProp::maximize(GaussianProcess * gp, size_t n, bool verbose)
+void RProp::maximize(GaussianProcess * gp, size_t n, bool verbose, bool print_params)
 {
   int param_dim = gp->covf().get_param_dim();
   Eigen::VectorXd Delta = Eigen::VectorXd::Ones(param_dim) * Delta0;
@@ -31,16 +31,18 @@ void RProp::maximize(GaussianProcess * gp, size_t n, bool verbose)
   Eigen::VectorXd best_params = params;
   double best = log(0);
 
+  float stepsize_factor = 1.0;
+
   for (size_t i=0; i<n; ++i) {
-    Eigen::VectorXd grad = -gp->log_likelihood_gradient();
+    Eigen::VectorXd grad = -stepsize_factor * gp->log_likelihood_gradient();
     grad_old = grad_old.cwiseProduct(grad);
     for (int j=0; j<grad_old.size(); ++j) {
       if (grad_old(j) > 0) {
-        Delta(j) = std::min(Delta(j)*etaplus, Deltamax);        
+        Delta(j) = std::min(Delta(j)*etaplus, Deltamax);
       } else if (grad_old(j) < 0) {
         Delta(j) = std::max(Delta(j)*etaminus, Deltamin);
         grad(j) = 0;
-      } 
+      }
       params(j) += -Utils::sign(grad(j)) * Delta(j);
     }
     grad_old = grad;
@@ -48,12 +50,28 @@ void RProp::maximize(GaussianProcess * gp, size_t n, bool verbose)
     gp->covf().set_loghyper(params);
     double lik = gp->log_likelihood();
     if (verbose) std::cout << i << " " << -lik << std::endl;
+    if (print_params) {
+      std::cout << "[" << params[0];
+      for (int ii = 1; ii < params.size(); ++ii) {
+        std::cout << ", " << params[ii];
+      }
+      std::cout << "]" << std::endl;
+    }
     if (lik > best) {
       best = lik;
       best_params = params;
+    }
+    else {
+      stepsize_factor /= 2;
+      if (verbose) std::cout << "no improvement in step " << i
+                             << ", reduced stepsize_factor to " << stepsize_factor << std::endl;
+      if (stepsize_factor < min_stepsize_factor) {
+        if (verbose) std::cout << "stepsize_factor below threshold, finishing" << std::endl;
+        break;
+      }
     }
   }
   gp->covf().set_loghyper(best_params);
 }
 
-}
+} // namespace libgp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,13 +1,3 @@
-INCLUDE(ExternalProject)
-
-# ----- Download and build gtest -----
-ExternalProject_Add(googletest
-  SVN_REPOSITORY "http://googletest.googlecode.com/svn/tags/release-1.7.0"
-  INSTALL_COMMAND ""
-  UPDATE_COMMAND ""
-  PREFIX "gtest"
-)
-
 FIND_PACKAGE(Threads REQUIRED)
 
 # ----- Testing -----


### PR DESCRIPTION
I added some functionality to the maximize() function in RProp:
- Print the current set of hyperparameters in every iteration if the user wants that. Default behaviour is unchanged.

I checked the behaviour of the function, especially what happens if I allow a large number of iterations (200). I found that after the first 50-100 iterations the method gets stuck and no updates to the best_params vector occur.
I therefore implemented a cooldown strategy:

Merging this would make #9 and #10 obsolete.
- If the new value of the target function is not better than the old decrease stepsize_factor which is multiplied with the calculated gp->log_likelihood_gradient. Initial value for stepsize_factor is 1.0 so for the first iterations the behaviour is unchanged.
- If the stepsize is smaller than a threshold (default: 1e-2) stop
